### PR TITLE
Update mt.psv

### DIFF
--- a/data/polls/mt.psv
+++ b/data/polls/mt.psv
@@ -1,7 +1,7 @@
 Polling firm | Commissioners | Fieldwork Start | Fieldwork End | Scope | Sample Size | Participation | Precision | PL   | PN   | PD  | AD  | MPM | Other |
 Sagalytics   | N/A           | 2019-05-11      | 2018-05-17    | E     | 600         | N/A           | 0.1       | 56.9 | 37.3 | 1.1 | 2.0 | N/A | 2.8   |
 MaltaToday   | N/A           | 2019-05-09      | 2019-05-15    | E     | 849         | N/A           | 0.1       | 57.8 | 39.1 | N/A | N/A | N/A | N/A   |
-MISCO        | Sunday Times  | 2019-05-08      | 2019-05-11    | E     | 402         | 77.0          | 0.1       | 55.0 | 40.0 | 1.0 | 1.0 | N/A | 3.4   |
+MISCO        | Sunday Times  | 2019-05-08      | 2019-05-11    | E     | 402         | 77.0          | 0.1       | 55.0 | 40.0 | N/A | N/A | N/A | 3.4   |
 MaltaToday   | N/A           | 2019-04-25      | 2019-05-03    | EN    | 602         | 77.8          | 0.1       | 58.0 | 38.1 | 1.1 | 1.3 | N/A | 1.6   |
 Sagalytics   | N/A           | 2019-04-23      | 2018-05-02    | EN    | 600         | N/A           | 0.1       | 55.2 | 39.0 | N/A | N/A | N/A | 5.8   |
 MaltaToday   | N/A           | 2019-03-28      | 2019-04-04    | EN    | 597         | 68.9          | 0.1       | 62.5 | 37.5 | 0.0 | 0.0 | 0.0 | 0.0   |

--- a/data/polls/mt.psv
+++ b/data/polls/mt.psv
@@ -1,4 +1,7 @@
 Polling firm | Commissioners | Fieldwork Start | Fieldwork End | Scope | Sample Size | Participation | Precision | PL   | PN   | PD  | AD  | MPM | Other |
+Sagalytics   | N/A           | 2019-05-11      | 2018-05-17    | E     | 600         | N/A           | 0.1       | 56.9 | 37.3 | 1.1 | 2.0 | N/A | 2.8   |
+MaltaToday   | N/A           | 2019-05-09      | 2019-05-15    | E     | 849         | N/A           | 0.1       | 57.8 | 39.1 | N/A | N/A | N/A | N/A   |
+MISCO        | Sunday Times  | 2019-05-08      | 2019-05-11    | E     | 402         | 77.0          | 0.1       | 55.0 | 40.0 | 1.0 | 1.0 | N/A | 3.4   |
 MaltaToday   | N/A           | 2019-04-25      | 2019-05-03    | EN    | 602         | 77.8          | 0.1       | 58.0 | 38.1 | 1.1 | 1.3 | N/A | 1.6   |
 Sagalytics   | N/A           | 2019-04-23      | 2018-05-02    | EN    | 600         | N/A           | 0.1       | 55.2 | 39.0 | N/A | N/A | N/A | 5.8   |
 MaltaToday   | N/A           | 2019-03-28      | 2019-04-04    | EN    | 597         | 68.9          | 0.1       | 62.5 | 37.5 | 0.0 | 0.0 | 0.0 | 0.0   |


### PR DESCRIPTION
For the MISCO poll of 8–11 May 2019, both PD and AD achieved <1. I wrote "1.0", but it's not necessarily the most accurate. Your call.