### PR TITLE
Update bg.psv

### DIFF
--- a/data/parties/bg.psv
+++ b/data/parties/bg.psv
@@ -1,16 +1,16 @@
-Citizens for European Development of Bulgaria | #0092CB | GERB
-Bulgarian Socialist Party                     | #BF0202 | BSP
-United Patriots                               | #00008B | OP
+Citizens for European Development of Bulgaria | #0056A7 | GERB
+Bulgarian Socialist Party                     | #D71921 | BSP
+United Patriots                               | #000000 | OP
 IMRO – Bulgarian National Movement            | #000000 | VMRO
 National Front for the Salvation of Bulgaria  | #1D2D5A | NFSB
-Attack                                        | #00563F | Attack
+Attack                                        | #00563F | Ataka
 Alternative for Bulgarian Revival             | #6C1D45 | ABV
-Movement for Rights and Freedoms              | #4682B4 | DPS
-Volya                                         | #8A058A | Volya
+Movement for Rights and Freedoms              | #0066B7 | DPS
+Volya                                         | #00718F | Volya
 Reformist Bloc                                | #1D2D5A | RB
-Democratic Bulgaria                           | #264B7F | DB
+Democratic Bulgaria                           | #004A80 | DB
 Democrats for a Strong Bulgaria               | #1E2A5B | DSB
 Yes, Bulgaria!                                | #518254 | YB
-There is such people                          | #14B3E4 | ITN
-Stand up.BG                                   | #808080 | IS.B
+There Are Such People                         | #4BB9DE | ITN
+Stand up.BG                                   | #5BA546 | IS.BG
 Revival                                       | #808080 | V


### PR DESCRIPTION
Changed color hexes for parties, based off colors used in [this Wikipedia article's source code](https://bg.wikipedia.org/wiki/%D0%9F%D0%B0%D1%80%D0%BB%D0%B0%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%80%D0%BD%D0%B8_%D0%B8%D0%B7%D0%B1%D0%BE%D1%80%D0%B8_%D0%B2_%D0%91%D1%8A%D0%BB%D0%B3%D0%B0%D1%80%D0%B8%D1%8F_(2021)#%D0%9D%D0%B0%D1%86%D0%B8%D0%BE%D0%BD%D0%B0%D0%BB%D0%BD%D0%B8).
Colors were checked against party logos and match the main theme. United Patriots' color was changed to VMRO's color, as they are the 'leading party' as far as current seats in parliament and there's no official color for this political alliance. Attack's short form was changed from 'Attack' to the Bulgarian name's transliteration - 'Ataka'. 'IS.B' was changed to 'IS.BG' to follow the Bulgarian original. Fixed ITN's translated name.

**Note**: Some things might require further changing. GERB is the full name of the party and is no longer used as an acronym for a longer party name, for instance. Certain parties are missing and certain parties/coalitions no longer exist - how should those be handled in this file?