### PR TITLE
Add new coalition to bg.psv

### DIFF
--- a/data/parties/bg.psv
+++ b/data/parties/bg.psv
@@ -16,3 +16,4 @@ Stand Up! Mutri out!                         | #5BA546 | ISMV
 Revival                                      | #C09F62 | V
 Republicans for Bulgaria                     | #2B4A99 | RzB
 Volya–NFSB                                   | #00718F | Vo–NFSB
+The Bulgarian Patriots                       | #000000 | BP


### PR DESCRIPTION
Adding new coalition, The Bulgarian Patriots, comprised of VMRO, Volya and NFSB.

Ready to merge.